### PR TITLE
Fix flip

### DIFF
--- a/function/_function-flip.scss
+++ b/function/_function-flip.scss
@@ -5,5 +5,8 @@
 @function flip() {
 	@if($direction == rtl) {
 		@return scaleX(-1);
+	} 
+	@else {
+		@return scaleX(1);
 	}
 }


### PR DESCRIPTION
If function `flip()` doesn't have an `@else` return value it will break the SCSS because: `transform:` will be an empty and unclosed property.